### PR TITLE
fix: fix taskkill

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -72,7 +72,7 @@ export function killPid(pid, signal = "SIGINT") {
         } catch (error) { }
 
     } else {
-        childProcess.execSync('taskkill /PID ' + pid + ' /T /F');
+        childProcess.execSync('taskkill /PID ' + pid + ' /T /F || true');
     }
 }
 


### PR DESCRIPTION
When we run `taskkill /T` we kill all the tree.
Then if we call again for already killed PID it will throw error which will fail.