### PR TITLE
Fix api level type detection for Xcode 10+ simulated devices

### DIFF
--- a/lib/ios-controller.ts
+++ b/lib/ios-controller.ts
@@ -466,10 +466,14 @@ export class IOSController {
                     .forEach(deviceObj => {
                         const status: Status = <Status>deviceObj.state.toLowerCase();
                         const apiLevel = /\d{1,3}(\.|\-)+.+|\d+/.exec(level)[0].replace("-", ".");
-                        const stringType = /\w+[a-z]/g.test(level) && /\w+[a-z]/g.exec(level)[0];
+                        const stringType = /(watchos|tvos|ios)/g.exec(level.toLowerCase())[0];
                         let type = DeviceType.SIMULATOR;
                         if (stringType) {
-                            type = stringType === "tv" ? DeviceType.TV : DeviceType.WATCH;
+                            if (stringType === "tvos") {
+                                type = DeviceType.TV;
+                            } else if (stringType === "watchos") {
+                                type = DeviceType.WATCH;
+                            }
                         }
 
                         const device = <IDevice>{


### PR DESCRIPTION
Have noted same issue, appears to do with how XCode10 describes ApiLevels . 
previously in XCode9 (iOS 11 etc) they are written as 
```
watchOS 4.3
tvOS 11.4
iOS 11.4

```
in newer XCode10 (iOS 12 etc) they are written as
```
com.apple.CoreSimulator.SimRuntime.tvOS-12-2
com.apple.CoreSimulator.SimRuntime.watchOS-5-2
com.apple.CoreSimulator.SimRuntime.iOS-12-2
```
and the string matching is just picking out `com` and therefore not matching anything, defaulting to `DeviceType.WATCH`  