### PR TITLE
fix: getCurrentFocusedScreen() on api29

### DIFF
--- a/lib/android-controller.ts
+++ b/lib/android-controller.ts
@@ -419,7 +419,7 @@ export class AndroidController {
     }
 
     public static getCurrentFocusedScreen(device: IDevice, commandTimeout: number = 1000) {
-        return this.executeAdbCommand(device, " shell dumpsys window windows | grep -E 'mCurrentFocus'", commandTimeout);
+        return this.executeAdbCommand(device, " shell dumpsys window windows | grep -E 'mSurface'", commandTimeout);
     }
 
     public static checkApiLevelIsLessThan(device: IDevice, apiLevel: number) {


### PR DESCRIPTION
On `api29` we fail to detect emulator is running because
 ```
adb shell dumpsys window windows | grep -E 'mCurrentFocus'
``` 
returns nothing.

It looks `adb shell dumpsys window windows | grep -E 'mSurface'` works properly on all devices.