### PR TITLE
chore: use only one uninstall function; rename some properties

### DIFF
--- a/lib/android-controller.d.ts
+++ b/lib/android-controller.d.ts
@@ -37,7 +37,7 @@ export declare class AndroidController {
     static startAdb(): void;
     static stopAdb(): void;
     static killAdbProcess(): void;
-    static isAppRunning(device: IDevice, appId: string): boolean;
+    static isAppRunning(device: IDevice, packageId: string): boolean;
     static getCurrentFocusedScreen(device: IDevice, commandTimeout?: number): string;
     static checkApiLevelIsLessThan(device: IDevice, apiLevel: number): boolean;
     static checkIfEmulatorIsResponding(device: IDevice): boolean;
@@ -48,8 +48,8 @@ export declare class AndroidController {
     static getInstalledApps(device: any): string[];
     static isAppInstalled(device: IDevice, packageId: any): boolean;
     static installApp(device: IDevice, testAppName: any, packageId?: string): string;
-    static uninstallApp(device: any, appId: any): void;
-    static stopApplication(device: IDevice, appId: any): void;
+    static uninstallApplication(device: any, packageId: any): void;
+    static stopApplication(device: IDevice, packageId: any): void;
     static executeKeyEvent(device: IDevice, keyEvent: AndroidKeyEvent | string | number): void;
     static getScreenshot(device: IDevice, dir: any, fileName: any): Promise<string>;
     static recordVideo(device: IDevice, dir: any, fileName: any, callback: () => Promise<any>): Promise<void>;

--- a/lib/android-controller.d.ts
+++ b/lib/android-controller.d.ts
@@ -45,9 +45,9 @@ export declare class AndroidController {
     static reinstallApplication(device: any, appFullName: any, packageId?: string): void;
     static refreshApplication(device: any, appFullName: any, packageId?: string): void;
     static startApplication(device: IDevice, packageId: string): void;
-    static getInstalledApps(device: any): string[];
+    static getInstalledApplications(device: any): string[];
     static isAppInstalled(device: IDevice, packageId: any): boolean;
-    static installApp(device: IDevice, testAppName: any, packageId?: string): string;
+    static installApplication(device: IDevice, testAppName: any, packageId?: string): string;
     static uninstallApplication(device: any, packageId: any): void;
     static stopApplication(device: IDevice, packageId: any): void;
     static executeKeyEvent(device: IDevice, keyEvent: AndroidKeyEvent | string | number): void;

--- a/lib/android-controller.ts
+++ b/lib/android-controller.ts
@@ -409,9 +409,9 @@ export class AndroidController {
         killProcessByName("adb.exe");
     }
 
-    public static isAppRunning(device: IDevice, appId: string) {
+    public static isAppRunning(device: IDevice, packageId: string) {
         const result = AndroidController.executeAdbShellCommand(device, "ps");
-        if (result.includes(appId)) {
+        if (result.includes(packageId)) {
             return true;
         } else {
             return false;
@@ -474,7 +474,7 @@ export class AndroidController {
 
     public static reinstallApplication(device, appFullName, packageId: string = undefined) {
         packageId = packageId || AndroidController.getPackageId(appFullName);
-        AndroidController.uninstallApp(device, packageId);
+        AndroidController.uninstallApplication(device, packageId);
         AndroidController.installApp(device, appFullName, packageId);
     }
 
@@ -505,7 +505,7 @@ export class AndroidController {
         let isAppInstalled = AndroidController.isAppInstalled(device, packageId);
         if (isAppInstalled) {
             logInfo("Uninstall a previous version " + packageId + " app.");
-            AndroidController.uninstallApp(device, packageId);
+            AndroidController.uninstallApplication(device, packageId);
         }
 
         const output = AndroidController.executeAdbCommand(device, ` install -r ${testAppName}`);
@@ -521,27 +521,27 @@ export class AndroidController {
         return packageId;
     }
 
-    public static uninstallApp(device, appId) {
-        const isAppInstalled = AndroidController.isAppInstalled(device, appId);
+    public static uninstallApplication(device, packageId) {
+        const isAppInstalled = AndroidController.isAppInstalled(device, packageId);
         if (isAppInstalled) {
-            AndroidController.stopApplication(device, appId);
-            const uninstallResult = AndroidController.executeAdbCommand(device, `uninstall ${appId}`);
+            AndroidController.stopApplication(device, packageId);
+            const uninstallResult = AndroidController.executeAdbCommand(device, `uninstall ${packageId}`);
             if (uninstallResult.includes("Success")) {
-                logInfo(appId + " successfully uninstalled.");
+                logInfo(packageId + " successfully uninstalled.");
             } else {
-                logError("Failed to uninstall " + appId + ". Error: " + uninstallResult);
+                logError("Failed to uninstall " + packageId + ". Error: " + uninstallResult);
             }
         } else {
-            logInfo(`Application: ${appId} is not installed!`);
+            logInfo(`Application: ${packageId} is not installed!`);
         }
 
-        if (AndroidController.getInstalledApps(device).some(app => app === appId)) {
+        if (AndroidController.getInstalledApps(device).some(app => app === packageId)) {
             logError("We couldn't uninstall application!");
         }
     }
 
-    public static stopApplication(device: IDevice, appId) {
-        AndroidController.executeAdbShellCommand(device, `am force-stop ${appId}`);
+    public static stopApplication(device: IDevice, packageId) {
+        AndroidController.executeAdbShellCommand(device, `am force-stop ${packageId}`);
     }
 
     public static executeKeyEvent(device: IDevice, keyEvent: AndroidKeyEvent | string | number) {

--- a/lib/android-controller.ts
+++ b/lib/android-controller.ts
@@ -475,7 +475,7 @@ export class AndroidController {
     public static reinstallApplication(device, appFullName, packageId: string = undefined) {
         packageId = packageId || AndroidController.getPackageId(appFullName);
         AndroidController.uninstallApplication(device, packageId);
-        AndroidController.installApp(device, appFullName, packageId);
+        AndroidController.installApplication(device, appFullName, packageId);
     }
 
     public static refreshApplication(device, appFullName, packageId: string = undefined) {
@@ -490,17 +490,17 @@ export class AndroidController {
         Promise.resolve(AndroidController.executeAdbShellCommand(device, commandToExecute));
     }
 
-    public static getInstalledApps(device) {
+    public static getInstalledApplications(device) {
         const list = AndroidController.executeAdbShellCommand(device, `pm list packages -3`).split("\n");
         return list;
     }
 
     public static isAppInstalled(device: IDevice, packageId) {
-        let isAppInstalled = AndroidController.getInstalledApps(device).some(pack => pack.includes(packageId));
+        let isAppInstalled = AndroidController.getInstalledApplications(device).some(pack => pack.includes(packageId));
         return isAppInstalled
     }
 
-    public static installApp(device: IDevice, testAppName, packageId: string = undefined) {
+    public static installApplication(device: IDevice, testAppName, packageId: string = undefined) {
         packageId = packageId || AndroidController.getPackageId(testAppName);
         let isAppInstalled = AndroidController.isAppInstalled(device, packageId);
         if (isAppInstalled) {
@@ -535,7 +535,7 @@ export class AndroidController {
             logInfo(`Application: ${packageId} is not installed!`);
         }
 
-        if (AndroidController.getInstalledApps(device).some(app => app === packageId)) {
+        if (AndroidController.getInstalledApplications(device).some(app => app === packageId)) {
             logError("We couldn't uninstall application!");
         }
     }

--- a/lib/device-controller.d.ts
+++ b/lib/device-controller.d.ts
@@ -9,17 +9,16 @@ export declare class DeviceController {
     static getDevices(query: IDevice): Promise<IDevice[]>;
     static startDevice(device: IDevice, options?: string, shouldHardResetDevices?: boolean): Promise<IDevice>;
     static refreshApplication(device: IDevice, appFullPath: any): Promise<void>;
-    static startApplication(device: IDevice, appFullPath: any, bundleId?: string): Promise<void>;
+    static startApplication(device: IDevice, appFullPath: any, appId?: string): Promise<void>;
     static getInstalledApplication(device: IDevice): Promise<string[]>;
     /**
      *
      * @param device { token: string, type: DeviceType, platform: Platform }
-     * @param bundleId or package id
+     * @param appId
      * @param appName required for ios devices
      */
-    static stopApplication(device: IDevice, bundleId: string, appName?: string): Promise<void>;
+    static stopApplication(device: IDevice, appId: string, appName?: string): Promise<void>;
     static getApplicationId(device: IDevice, appFullPath: any): string;
-    static uninstallApp(device: IDevice, appFullPath: any): Promise<void>;
     static startRecordingVideo(device: IDevice, dir: any, fileName: any): {
         pathToVideo: string;
         videoRecoringProcess: any;
@@ -35,9 +34,9 @@ export declare class DeviceController {
     static filter(devices: Array<IDevice>, searchQuery: any): IDevice[];
     static getScreenshot(device: IDevice, dir: any, fileName: any): Promise<string>;
     static recordVideo(device: IDevice, dir: any, fileName: any, callback: () => Promise<any>): Promise<any>;
-    static reinstallApplication(device: IDevice, appFullName: string, bundleId: any): Promise<void>;
-    static installApplication(device: IDevice, appFullName: string, bundleId?: string): Promise<string | void>;
-    static uninstallAppWithBundle(device: IDevice, appId: any): Promise<void>;
+    static reinstallApplication(device: IDevice, appFullName: string, appId: any): Promise<void>;
+    static installApplication(device: IDevice, appFullName: string, appId?: string): Promise<string | void>;
+    static uninstallApplication(device: IDevice, appFullName: string, appId?: string): Promise<string | void>;
     static copyProperties(from: IDevice): IDevice;
     private static mapDevicesToArray;
 }

--- a/lib/device-controller.ts
+++ b/lib/device-controller.ts
@@ -42,11 +42,11 @@ export class DeviceController {
         }
     }
 
-    public static async startApplication(device: IDevice, appFullPath, bundleId: string = undefined): Promise<void> {
+    public static async startApplication(device: IDevice, appFullPath, appId: string = undefined): Promise<void> {
         if (device.platform === Platform.IOS) {
-            await IOSController.startApplication(device, appFullPath, bundleId)
+            await IOSController.startApplication(device, appFullPath, appId)
         } else {
-            await AndroidController.startApplication(device, bundleId);
+            await AndroidController.startApplication(device, appId);
         }
     }
 
@@ -61,32 +61,22 @@ export class DeviceController {
     /**
      * 
      * @param device { token: string, type: DeviceType, platform: Platform }
-     * @param bundleId or package id 
+     * @param appId 
      * @param appName required for ios devices
      */
-    public static async stopApplication(device: IDevice, bundleId: string, appName?: string): Promise<void> {
+    public static async stopApplication(device: IDevice, appId: string, appName?: string): Promise<void> {
         if (device.platform === Platform.IOS || device.type === DeviceType.SIMULATOR) {
-            await IOSController.stopApplication(device, bundleId, appName)
+            await IOSController.stopApplication(device, appId, appName)
         } else {
-            await AndroidController.stopApplication(device, bundleId);
+            await AndroidController.stopApplication(device, appId);
         }
     }
 
     public static getApplicationId(device: IDevice, appFullPath): string {
         if (device.platform === Platform.IOS) {
-            return IOSController.getIOSPackageId(device.type, appFullPath)
+            return IOSController.getBundleId(device.type, appFullPath);
         } else {
             return AndroidController.getPackageId(appFullPath);
-        }
-    }
-
-    public static async uninstallApp(device: IDevice, appFullPath): Promise<void> {
-        if (device.platform === Platform.IOS) {
-            const bundleId = IOSController.getIOSPackageId(device.type, appFullPath);
-            await IOSController.uninstallApp(device, appFullPath, bundleId)
-        } else {
-            const packageId = AndroidController.getPackageId(appFullPath);
-            await AndroidController.uninstallApp(device, packageId);
         }
     }
 
@@ -181,27 +171,28 @@ export class DeviceController {
         }
     }
 
-    public static async reinstallApplication(device: IDevice, appFullName: string, bundleId) {
+    public static async reinstallApplication(device: IDevice, appFullName: string, appId) {
         if (device.type === DeviceType.EMULATOR || device.platform === Platform.ANDROID) {
-            return await AndroidController.reinstallApplication(device, appFullName, bundleId);
+            return await AndroidController.reinstallApplication(device, appFullName, appId);
         } else {
-            return await IOSController.reinstallApplication(device, appFullName, bundleId);
+            return await IOSController.reinstallApplication(device, appFullName, appId);
         }
     }
 
-    public static async installApplication(device: IDevice, appFullName: string, bundleId: string = undefined) {
+    public static async installApplication(device: IDevice, appFullName: string, appId: string = undefined) {
         if (device.type === DeviceType.EMULATOR || device.platform === Platform.ANDROID) {
-            return await AndroidController.installApp(device, appFullName, bundleId);
+            return await AndroidController.installApp(device, appFullName, appId);
         } else {
             return await IOSController.installApp(device, appFullName);
         }
     }
 
-    public static async uninstallAppWithBundle(device: IDevice, appId) {
+    public static async uninstallApplication(device: IDevice, appFullPath, appId: string = undefined): Promise<void> {
+        appId = appId || DeviceController.getApplicationId(device, appFullPath);
         if (device.type === DeviceType.EMULATOR || device.platform === Platform.ANDROID) {
-            return await AndroidController.uninstallApp(device, appId);
+            return await AndroidController.uninstallApplication(device, appId);
         } else {
-            return await IOSController.uninstallApp(device, undefined, appId);
+            return await IOSController.uninstallApplication(device, appFullPath, appId);
         }
     }
 

--- a/lib/device-controller.ts
+++ b/lib/device-controller.ts
@@ -52,9 +52,9 @@ export class DeviceController {
 
     public static async getInstalledApplication(device: IDevice): Promise<string[]> {
         if (device.platform === Platform.IOS) {
-            return await IOSController.getInstalledApps(device);
+            return await IOSController.getInstalledApplications(device);
         } else {
-            return await AndroidController.getInstalledApps(device);
+            return await AndroidController.getInstalledApplications(device);
         }
     }
 
@@ -181,9 +181,9 @@ export class DeviceController {
 
     public static async installApplication(device: IDevice, appFullName: string, appId: string = undefined) {
         if (device.type === DeviceType.EMULATOR || device.platform === Platform.ANDROID) {
-            return await AndroidController.installApp(device, appFullName, appId);
+            return await AndroidController.installApplication(device, appFullName, appId);
         } else {
-            return await IOSController.installApp(device, appFullName);
+            return await IOSController.installApplication(device, appFullName);
         }
     }
 

--- a/lib/ios-controller.d.ts
+++ b/lib/ios-controller.d.ts
@@ -32,7 +32,7 @@ export declare class IOSController {
     * @param appName - should be provided when DeviceType.SIMULATOR else undefined
     **/
     static stopApplication(device: IDevice, bundleId: string, appName: string): Promise<boolean>;
-    static uninstallApp(device: IDevice, fullAppName: string, bundleId?: string): Promise<void>;
+    static uninstallApplication(device: IDevice, fullAppName: string, bundleId?: string): Promise<void>;
     static reinstallApplication(device: IDevice, fullAppName: any, bundleId?: string): Promise<void>;
     static refreshApplication(device: IDevice, fullAppName: any, bundleId?: string): Promise<void>;
     static startApplication(device: IDevice, fullAppName: any, bundleId?: string): Promise<{
@@ -52,7 +52,7 @@ export declare class IOSController {
         videoRecoringProcess: any;
     };
     private static checkIfSimulatorIsBooted;
-    static getIOSPackageId(deviceType: DeviceType, fullAppName: any): string;
+    static getBundleId(deviceType: DeviceType, fullAppName: any): string;
     static getDevicesScreenInfo(): Map<string, IOSDeviceScreenInfo>;
     /**
      * Get path of Info.plist of iOS app under test.

--- a/lib/ios-controller.d.ts
+++ b/lib/ios-controller.d.ts
@@ -24,8 +24,8 @@ export declare class IOSController {
     static restartDevice(device: IDevice): Promise<void>;
     static killAll(): void;
     static kill(udid: string): Promise<void>;
-    static getInstalledApps(device: IDevice): any[];
-    static installApp(device: IDevice, fullAppName: any): Promise<void>;
+    static getInstalledApplications(device: IDevice): any[];
+    static installApplication(device: IDevice, fullAppName: any): Promise<void>;
     /**
     * @param device - of type {token: string, type: DeviceType}
     * @param bundleId - should be provided when DeviceType.DEVICE else undefined

--- a/lib/ios-controller.ts
+++ b/lib/ios-controller.ts
@@ -357,7 +357,7 @@ export class IOSController {
     * @param bundleId - should be provided when DeviceType.DEVICE else undefined
     * @param appName - should be provided when DeviceType.SIMULATOR else undefined
     **/
-    public static async stopApplication(device: IDevice, bundleId: string, appName: string): Promise<boolean> {
+   public static async stopApplication(device: IDevice, bundleId: string, appName: string): Promise<boolean> {
         const apps = IOSController.getInstalledApps(device);
         if (apps.some(app => app.includes(bundleId))) {
             if (!device.type) {
@@ -389,16 +389,11 @@ export class IOSController {
         }
     }
 
-    public static async uninstallApp(device: IDevice, fullAppName: string, bundleId: string = undefined) {
-        bundleId = bundleId || IOSController.getIOSPackageId(device.type, fullAppName);
+    public static async uninstallApplication(device: IDevice, fullAppName: string, bundleId: string = undefined) {
+        bundleId = bundleId || IOSController.getBundleId(device.type, fullAppName);
         let result = "";
         try {
-            if (!fullAppName) {
-                await IOSController.stopApplication(device, bundleId, fullAppName);
-            }
-            else {
-                await IOSController.stopApplication(device, bundleId, basename(fullAppName));
-            }
+            await IOSController.stopApplication(device, bundleId, !fullAppName ? fullAppName : basename(fullAppName));
             wait(500);
         } catch (error) {
             console.dir(error);
@@ -412,19 +407,19 @@ export class IOSController {
     }
 
     public static async reinstallApplication(device: IDevice, fullAppName, bundleId: string = undefined) {
-        bundleId = bundleId || IOSController.getIOSPackageId(device.type, fullAppName);
-        await IOSController.uninstallApp(device, fullAppName, bundleId);
+        bundleId = bundleId || IOSController.getBundleId(device.type, fullAppName);
+        await IOSController.uninstallApplication(device, fullAppName, bundleId);
         await IOSController.installApp(device, fullAppName);
     }
 
     public static async refreshApplication(device: IDevice, fullAppName, bundleId: string = undefined) {
-        bundleId = bundleId || IOSController.getIOSPackageId(device.type, fullAppName);
+        bundleId = bundleId || IOSController.getBundleId(device.type, fullAppName);
         await IOSController.reinstallApplication(device, fullAppName, bundleId);
         await IOSController.startApplication(device, fullAppName, bundleId);
     }
 
     public static async startApplication(device: IDevice, fullAppName, bundleId: string = undefined): Promise<{ output: string, result: boolean }> {
-        bundleId = bundleId || IOSController.getIOSPackageId(device.type, fullAppName);
+        bundleId = bundleId || IOSController.getBundleId(device.type, fullAppName);
         let output = "";
         let result = false;
         if (device.type === DeviceType.DEVICE) {
@@ -710,7 +705,7 @@ export class IOSController {
         return booted;
     }
 
-    public static getIOSPackageId(deviceType: DeviceType, fullAppName) {
+    public static getBundleId(deviceType: DeviceType, fullAppName) {
         let result = "";
         const plistPath = IOSController.getPlistPath(fullAppName);
 

--- a/lib/ios-controller.ts
+++ b/lib/ios-controller.ts
@@ -306,7 +306,7 @@ export class IOSController {
         await killAllProcessAndRelatedCommand(udid);
     }
 
-    public static getInstalledApps(device: IDevice) {
+    public static getInstalledApplications(device: IDevice) {
         const apps = new Array();
         if (device.type === DeviceType.DEVICE) {
             const rowData = executeCommand(`ideviceinstaller -u ${device.token} -l`).replace("package:", "").split("\n");
@@ -333,7 +333,7 @@ export class IOSController {
         return apps;
     }
 
-    public static async installApp(device: IDevice, fullAppName) {
+    public static async installApplication(device: IDevice, fullAppName) {
         if (device.type === DeviceType.DEVICE) {
             const installProcess = await (await IOSController.getDl()).install(fullAppName, [device.token])[0];
             await IOSController.disposeDL();
@@ -358,7 +358,7 @@ export class IOSController {
     * @param appName - should be provided when DeviceType.SIMULATOR else undefined
     **/
    public static async stopApplication(device: IDevice, bundleId: string, appName: string): Promise<boolean> {
-        const apps = IOSController.getInstalledApps(device);
+        const apps = IOSController.getInstalledApplications(device);
         if (apps.some(app => app.includes(bundleId))) {
             if (!device.type) {
                 device.platform = Platform.IOS;
@@ -409,7 +409,7 @@ export class IOSController {
     public static async reinstallApplication(device: IDevice, fullAppName, bundleId: string = undefined) {
         bundleId = bundleId || IOSController.getBundleId(device.type, fullAppName);
         await IOSController.uninstallApplication(device, fullAppName, bundleId);
-        await IOSController.installApp(device, fullAppName);
+        await IOSController.installApplication(device, fullAppName);
     }
 
     public static async refreshApplication(device: IDevice, fullAppName, bundleId: string = undefined) {

--- a/lib/ios/ios-virtulal-device.spec.ts
+++ b/lib/ios/ios-virtulal-device.spec.ts
@@ -253,7 +253,7 @@ describe("start and kill ios device", async () => {
             await IOSController.installApp(device, appToInstall);
             let startAppResult = await IOSController.startApplication(device, appToInstall);
             await IOSController.stopApplication(device, appBundleId, appName);
-            let uninstallApp = await IOSController.uninstallApp(device, appToInstall, appBundleId);
+            let uninstallApp = await IOSController.uninstallApplication(device, appToInstall, appBundleId);
             let apps = await IOSController.getInstalledApps(device);
             assert.isTrue(!apps.some(app => app.includes(appName)));
 

--- a/lib/ios/ios-virtulal-device.spec.ts
+++ b/lib/ios/ios-virtulal-device.spec.ts
@@ -250,16 +250,16 @@ describe("start and kill ios device", async () => {
                 device = (await DeviceController.getDevices(deviceQuery))[0];
                 device = await IOSController.startSimulator(device);
             }
-            await IOSController.installApp(device, appToInstall);
+            await IOSController.installApplication(device, appToInstall);
             let startAppResult = await IOSController.startApplication(device, appToInstall);
             await IOSController.stopApplication(device, appBundleId, appName);
             let uninstallApp = await IOSController.uninstallApplication(device, appToInstall, appBundleId);
-            let apps = await IOSController.getInstalledApps(device);
+            let apps = await IOSController.getInstalledApplications(device);
             assert.isTrue(!apps.some(app => app.includes(appName)));
 
-            await IOSController.installApp(device, appToInstall);
-            await IOSController.installApp(device, appToInstall);
-            apps = await IOSController.getInstalledApps(device);
+            await IOSController.installApplication(device, appToInstall);
+            await IOSController.installApplication(device, appToInstall);
+            apps = await IOSController.getInstalledApplications(device);
             startAppResult = await IOSController.startApplication(device, appToInstall);
             assert.isTrue(startAppResult.result);
             await IOSController.stopApplication(device, appBundleId, appName);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobile-devices-controller",
-    "version": "4.0.3-8",
+    "version": "5.0.0",
     "main": "index.js",
     "description": "Manage devices, emulators and simulators.",
     "keywords": [


### PR DESCRIPTION
- in `device-controller`
   - use only `appId`
   - expose only one uninstall function - `uninstallApplication` instead of `uninstallApp` and `uninstallAppWithBundle` - BREAKING CHANGE
- in `android-controller`
   - use only `packageId`
   - renamed `uninstallApp` to `uninstallApplication` to be consistent with other function names
- in `ios-controller`
   - use only `bundleId`
   - renamed `getIOSPackageId` to `getBundleId`
   - renamed `uninstallApp` to `uninstallApplication` to be consistent with other function names

